### PR TITLE
feat: add state statistic

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -3,6 +3,9 @@ use crate::config::Config;
 use crate::error::{Error, ErrorKind};
 use derive_more::Display;
 use std::{convert::TryFrom, str::FromStr};
+use mpd::State as MPDState;
+use mpris::PlaybackStatus as MPRISState;
+
 #[derive(Debug, Clone, Copy, Display, serde::Deserialize)]
 pub enum Player {
     Mpd,
@@ -87,18 +90,16 @@ pub enum State {
     Stopped,
 }
 
-use mpris::PlaybackStatus;
-impl From<PlaybackStatus> for State {
-    fn from(playback_status: mpris::PlaybackStatus) -> State {
+impl From<MPRISState> for State {
+    fn from(playback_status: MPRISState) -> State {
         match playback_status {
-            PlaybackStatus::Paused => State::Paused,
-            PlaybackStatus::Playing => State::Playing,
-            PlaybackStatus::Stopped => State::Stopped,
+            MPRISState::Paused => State::Paused,
+            MPRISState::Playing => State::Playing,
+            MPRISState::Stopped => State::Stopped,
         }
     }
 }
 
-use mpd::State as MPDState;
 impl From<MPDState> for State {
     fn from(playback_status: mpd::State) -> State {
         match playback_status {
@@ -118,7 +119,7 @@ pub struct PlayerInfo {
 }
 
 impl std::fmt::Display for PlayerInfo {
-   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Player: {}", self.kind)?;
         writeln!(f, "State: {}", self.state)?;
         writeln!(f, "Title: {}", self.title)?;
@@ -128,10 +129,10 @@ impl std::fmt::Display for PlayerInfo {
             write!(f, "Artist: ")?;
         }
         for (count, artist) in self.artists.iter().enumerate() {
+            write!(f, "{}", artist)?;
             if count != 0 {
                 write!(f, ", ")?
             }
-            write!(f, "{}", artist)?;
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,12 +15,11 @@ fn main() -> Result<(), Error> {
 
     let mut control = control::Control::with_config(config).unwrap();
 
-    let player: Player;
-    if matches.is_present("player") {
-        player = matches.value_of("player").unwrap().parse::<Player>()?;
+    let player = if matches.is_present("player") {
+        matches.value_of("player").unwrap().parse::<Player>()?
     } else {
-        player = control.player()?;
-    }
+        control.player()?
+    };
 
     control.handle(operation, player)?;
     Ok(())


### PR DESCRIPTION
`PlayerInfo` now exposes a `state` attribute, which works for both Mpris, and Mpd. It implements `From` for both of Mpris and Mpd's Status structs, preserving the original uncommented code.